### PR TITLE
Refactor Tile Class and Board Initialization

### DIFF
--- a/src/logic/Board.ts
+++ b/src/logic/Board.ts
@@ -21,7 +21,10 @@ export class Board implements IBoard {
   }
 
   getNeighbours(coord: HexCoordinates) {
-    const ringTraverser: Traverser<Tile> = ring({ center: coord, radius: 1 }) as Traverser<Tile>;
+    const ringTraverser: Traverser<Tile> = ring({
+      center: coord,
+      radius: 1,
+    }) as Traverser<Tile>;
     return this.grid.traverse(ringTraverser);
   }
 

--- a/src/logic/Board.ts
+++ b/src/logic/Board.ts
@@ -7,26 +7,26 @@ import {
   ring,
   spiral,
   toCube,
+  Traverser,
 } from "honeycomb-grid";
 
 import IBoard from "../types/IBoard";
-import ITile from "../types/ITile";
 import { Tile } from "./Tile";
 
 export class Board implements IBoard {
-  grid: Grid<ITile>;
+  grid: Grid<Tile>;
 
   constructor() {
-    this.grid = new Grid(Tile, spiral({ radius: 4 })) as Grid<ITile>;
+    this.grid = new Grid(Tile, spiral({ radius: 4 }));
   }
 
   getNeighbours(coord: HexCoordinates) {
-    const ringTraverser = ring({ center: coord, radius: 1 });
+    const ringTraverser: Traverser<Tile> = ring({ center: coord, radius: 1 }) as Traverser<Tile>;
     return this.grid.traverse(ringTraverser);
   }
 
   getInnerNeighbours(coord: HexCoordinates) {
-    return this.getNeighbours(coord).filter((tile) => !tile?.isOuterTile?.());
+    return this.getNeighbours(coord).filter((tile) => !tile.isOuterTile());
   }
 
   printBoard(): void {

--- a/src/logic/Tile.ts
+++ b/src/logic/Tile.ts
@@ -1,8 +1,13 @@
-import { Hex } from "honeycomb-grid";
+import { Hex, HexCoordinates } from "honeycomb-grid";
 import ITile from "../types/ITile";
 
 export class Tile extends Hex implements ITile {
-  fill = "";
+  fill: string;
+
+  constructor(coordinates?: HexCoordinates) {
+    super(coordinates);
+    this.fill = "";
+  }
 
   isOuterTile() {
     return [this.q, this.r, this.s].some((value) => Math.abs(value) === 4);

--- a/src/tests/tile.test.ts
+++ b/src/tests/tile.test.ts
@@ -27,8 +27,8 @@ test("I can set the fill property of a tile to 'W'; I can then access this fill 
   const tile = board.grid.getHex([0, 1, -1]);
 
   tile &&
-  typeof tile.setFill === "function" &&
-  typeof tile.getFill === "function"
+    typeof tile.setFill === "function" &&
+    typeof tile.getFill === "function"
     ? (tile.setFill("W"), expect(tile.getFill()).toBe("W"))
     : fail("tile is undefined");
 });

--- a/src/tests/tile.test.ts
+++ b/src/tests/tile.test.ts
@@ -27,8 +27,8 @@ test("I can set the fill property of a tile to 'W'; I can then access this fill 
   const tile = board.grid.getHex([0, 1, -1]);
 
   tile &&
-    typeof tile.setFill === "function" &&
-    typeof tile.getFill === "function"
+  typeof tile.setFill === "function" &&
+  typeof tile.getFill === "function"
     ? (tile.setFill("W"), expect(tile.getFill()).toBe("W"))
     : fail("tile is undefined");
 });

--- a/src/types/ITile.ts
+++ b/src/types/ITile.ts
@@ -1,10 +1,10 @@
 import { Hex } from "honeycomb-grid";
 
 interface ITile extends Hex {
-  fill?: string;
-  isOuterTile?(): boolean;
-  getFill?(): string;
-  setFill?(state: string): void;
+  fill: string;
+  isOuterTile(): boolean;
+  getFill(): string;
+  setFill(state: string): void;
 }
 
 export default ITile;


### PR DESCRIPTION
### Key Changes:

- **Tile Class Constructor**: Refactored the Tile class to include a constructor that accepts HexCoordinates. This ensures that every Tile instance is created with specific coordinates, aligning it with the expected structure of the honeycomb-grid library.
- **Board Initialization**: Refined the way the Grid is initialized in the Board class to work with the updated Tile class.
- **Code Clean-Up**: Removed unnecessary optional chaining (?.)