### PR TITLE
GIPF-77 render board

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -33,11 +33,14 @@ const server = Bun.serve<{ name: string; }>({
         ws.unsubscribe("lobby");
         ws.subscribe(room.id);
         console.log(`added ${message.data.name} to room ${room.id}`)
-        let response: RoomJoinedData = { type: "roomJoined", data: {
-          room: room.id,
-          playerColour: "1",
-          grid: room.game.board.serialise()
-        } }
+        let response: RoomJoinedData = {
+          type: "roomJoined", data:
+          {
+            room: room.id,
+            playerColour: "1",
+            grid: room.game.board.serialise()
+          }
+        }
         ws.send(JSON.stringify(response))
       }
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -33,7 +33,11 @@ const server = Bun.serve<{ name: string; }>({
         ws.unsubscribe("lobby");
         ws.subscribe(room.id);
         console.log(`added ${message.data.name} to room ${room.id}`)
-        let response: RoomJoinedData = { type: "roomJoined", data: { room: room.id } }
+        let response: RoomJoinedData = { type: "roomJoined", data: {
+          room: room.id,
+          playerColour: "1",
+          grid: room.game.board.serialise()
+        } }
         ws.send(JSON.stringify(response))
       }
 

--- a/backend/src/logic/Board.ts
+++ b/backend/src/logic/Board.ts
@@ -17,6 +17,7 @@ import { vectors, IBoard } from "../shared/types/index";
 
 // Component imports
 import { Tile } from "./Tile";
+import { GridHexData } from "../shared/types/gridhexdata";
 
 export class Board implements IBoard {
   grid: Grid<Tile>;
@@ -54,7 +55,7 @@ export class Board implements IBoard {
    */
   serialise(): string {
     console.log(this.grid.toJSON());
-    const griddata: any[] = [];
+    const griddata: GridHexData[] = [];
     this.grid.forEach((hex) => {
       griddata.push({
         q: hex.q,

--- a/backend/src/logic/Board.ts
+++ b/backend/src/logic/Board.ts
@@ -61,6 +61,7 @@ export class Board implements IBoard {
         r: hex.r,
         corners: hex.corners,
         fill: hex.fill,
+        center: hex.center,
       });
     });
     return JSON.stringify(griddata);

--- a/backend/src/logic/Board.ts
+++ b/backend/src/logic/Board.ts
@@ -61,7 +61,7 @@ export class Board implements IBoard {
         r: hex.r,
         corners: hex.corners,
         fill: hex.fill,
-        center: hex.center,
+        outer: hex.isOuterTile(),
       });
     });
     return JSON.stringify(griddata);

--- a/backend/src/logic/Board.ts
+++ b/backend/src/logic/Board.ts
@@ -54,11 +54,16 @@ export class Board implements IBoard {
    */
   serialise(): string {
     console.log(this.grid.toJSON());
-    const griddata: any[] = []
-    this.grid.forEach(hex => {
-      griddata.push({"q": hex.q, "r": hex.r, "corners": hex.corners, "fill": hex.fill})
-    })
-    return JSON.stringify(griddata)
+    const griddata: any[] = [];
+    this.grid.forEach((hex) => {
+      griddata.push({
+        q: hex.q,
+        r: hex.r,
+        corners: hex.corners,
+        fill: hex.fill,
+      });
+    });
+    return JSON.stringify(griddata);
   }
 
   fillTile(coord: HexCoordinates, player: "black" | "white"): void {

--- a/backend/src/logic/Board.ts
+++ b/backend/src/logic/Board.ts
@@ -50,10 +50,15 @@ export class Board implements IBoard {
   }
 
   /**
-   * Prints the board's state to the console.
+   * Creates a string from the board's state.
    */
-  printBoard(): void {
+  serialise(): string {
     console.log(this.grid.toJSON());
+    const griddata: any[] = []
+    this.grid.forEach(hex => {
+      griddata.push({"q": hex.q, "r": hex.r, "corners": hex.corners, "fill": hex.fill})
+    })
+    return JSON.stringify(griddata)
   }
 
   fillTile(coord: HexCoordinates, player: "black" | "white"): void {

--- a/backend/src/logic/Tile.ts
+++ b/backend/src/logic/Tile.ts
@@ -1,7 +1,10 @@
-import { Hex, HexCoordinates, defineHex } from "honeycomb-grid";
+import { HexCoordinates, defineHex } from "honeycomb-grid";
 import { ITile } from "../shared/types/index";
 
-export class Tile extends defineHex({ dimensions: 50, origin: 'topLeft' }) implements ITile {
+export class Tile
+  extends defineHex({ dimensions: 50, origin: "topLeft" })
+  implements ITile
+{
   fill: string;
 
   constructor(coordinates?: HexCoordinates) {

--- a/backend/src/logic/Tile.ts
+++ b/backend/src/logic/Tile.ts
@@ -1,7 +1,7 @@
-import { Hex, HexCoordinates } from "honeycomb-grid";
+import { Hex, HexCoordinates, defineHex } from "honeycomb-grid";
 import { ITile } from "../shared/types/index";
 
-export class Tile extends Hex implements ITile {
+export class Tile extends defineHex({ dimensions: 50, origin: 'topLeft' }) implements ITile {
   fill: string;
 
   constructor(coordinates?: HexCoordinates) {

--- a/backend/src/shared/types/gridhexdata.ts
+++ b/backend/src/shared/types/gridhexdata.ts
@@ -1,0 +1,9 @@
+import { Point } from "honeycomb-grid";
+
+export type GridHexData = {
+  fill: string;
+  q: number;
+  r: number;
+  corners: Point[];
+  outer: boolean;
+};

--- a/backend/src/shared/types/message.ts
+++ b/backend/src/shared/types/message.ts
@@ -1,5 +1,4 @@
-import { Grid, HexCoordinates } from "honeycomb-grid";
-import { ITile } from "./ITile";
+import { HexCoordinates } from "honeycomb-grid";
 
 export interface Message {
   type: "join" | "roomJoined" | "lobby" | "move";

--- a/backend/src/shared/types/message.ts
+++ b/backend/src/shared/types/message.ts
@@ -1,4 +1,5 @@
-import { HexCoordinates } from "honeycomb-grid";
+import { Grid, HexCoordinates } from "honeycomb-grid";
+import { ITile } from "./ITile";
 
 export interface Message {
   type: "join" | "roomJoined" | "lobby" | "move";
@@ -7,7 +8,11 @@ export interface Message {
 
 export interface RoomJoinedData extends Message {
   type: "roomJoined";
-  data: { room: string };
+  data: {
+    room: string;
+    playerColour: string;
+    grid: string;
+  };
 }
 
 export interface JoinData extends Message {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ function App() {
   const [colour, setColour] = useState<string | null>(null)
   const [hexes, setHexes] = useState<any[] | null>(null)
 
+
   useEffect(() => {
     // Connect to server
     const mysocket = new WebSocket(wsAddress);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,4 @@
 import { ChangeEvent, useEffect, useState } from 'react'
-import { Grid } from "honeycomb-grid";
 import './App.css'
 import { Board } from './components/Board';
 
@@ -37,7 +36,6 @@ function App() {
 
         console.log(grid)
         setHexes(grid)
-        // grid.forEach(hex => console.log(hex.corners))
       }
     }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { ChangeEvent, useEffect, useState } from 'react'
+import { Grid } from "honeycomb-grid";
 import './App.css'
+import { Board } from './components/Board';
 
 const wsAddress: string = "ws://localhost:3000";
 
@@ -8,6 +10,8 @@ function App() {
   const [socketConnected, setSocketConnected] = useState(false)
   const [name, setName] = useState("")
   const [room, setRoom] = useState(null)
+  const [colour, setColour] = useState<string | null>(null)
+  const [hexes, setHexes] = useState<any[] | null>(null)
 
   useEffect(() => {
     // Connect to server
@@ -20,10 +24,19 @@ function App() {
     }
     // Log messages from server
     mysocket.onmessage = msg => {
-      console.log("message", msg.data);
+      // console.log("message", msg.data);
       const messageData = JSON.parse(msg.data)
+
+      // on joining room, room and player colour are set
+      // board is loaded
       if(messageData.type == "roomJoined") {
         setRoom(messageData.data.room)
+        messageData.data.playerColour == "1" ? setColour("W") : setColour("B")
+        const grid = JSON.parse(messageData.data.grid)
+
+        console.log(grid)
+        setHexes(grid)
+        // grid.forEach(hex => console.log(hex.corners))
       }
     }
 
@@ -66,6 +79,7 @@ function App() {
           </button>
         </div>
       }
+      {hexes && <Board hexes={hexes} />}
     </>
   )
 }

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -11,15 +11,6 @@ export type HexagonProps = {
 
 export const Board = ({ hexes } ) => {
 
-  // const Hex = defineHex({ dimensions: 50, origin: 'topLeft' })
-  // const grid = new Grid(Hex, spiral({radius: 3}))
-
-  // const hexagondata: HexagonProps[] = []
-
-  // grid.forEach((hex) => {
-  //   hexagondata.push({coords: hex.toString(), points: hex.corners, center: hex.center, piece: "B", isOuter: true})
-  // })
-
   const hexdata: HexagonProps[] = hexes.map(hex => {
     return {
       coords: JSON.stringify({q: hex.q, r: hex.r}),

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,0 +1,34 @@
+import { defineHex, Grid, spiral, Point } from 'honeycomb-grid'
+import { Hexagon } from "./Hexagon"
+
+export type HexagonProps = {
+  coords: string;
+  points: Point[];
+  piece?: string;
+  isOuter: boolean;
+}
+
+export const Board = () => {
+
+  const Hex = defineHex({ dimensions: 50, origin: 'topLeft' })
+  const grid = new Grid(Hex, spiral({radius: 3}))
+
+  const hexagondata: HexagonProps[] = []
+
+  grid.forEach((hex) => {
+    hexagondata.push({coords: hex.toString(), points: hex.corners, piece: "B", isOuter: true})
+  })
+
+  return (<svg
+  className="grid"
+  width="800"
+  height="600"
+  viewBox="-350 -250 800 600"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <g>
+    {hexagondata.map((h) => <Hexagon data={h} />)}
+  </g>
+</svg>)
+}

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -5,8 +5,7 @@ export type HexagonProps = {
   coords: string;
   points: Point[];
   piece?: string;
-  isOuter: boolean;
-  center?: Point;
+  outer: boolean;
 }
 
 type GridHexData = {
@@ -14,7 +13,7 @@ type GridHexData = {
   q: number;
   r: number;
   corners: Point[];
-  center: Point;
+  outer: boolean;
 }
 
 export const Board = ( {hexes}: {hexes: GridHexData[]} ) => {
@@ -25,8 +24,7 @@ export const Board = ( {hexes}: {hexes: GridHexData[]} ) => {
       coords: JSON.stringify({q: hex.q, r: hex.r}),
       points: hex.corners,
       piece: hex.fill,
-      center: hex.center,
-      isOuter: true
+      outer: hex.outer
     }} key={JSON.stringify({q: hex.q, r: hex.r})} />
   })
 

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,4 +1,4 @@
-import { defineHex, Grid, spiral, Point } from 'honeycomb-grid'
+import { Point } from 'honeycomb-grid'
 import { Hexagon } from "./Hexagon"
 
 export type HexagonProps = {
@@ -6,29 +6,39 @@ export type HexagonProps = {
   points: Point[];
   piece?: string;
   isOuter: boolean;
+  center?: Point;
 }
 
-export const Board = () => {
+export const Board = ({ hexes } ) => {
 
-  const Hex = defineHex({ dimensions: 50, origin: 'topLeft' })
-  const grid = new Grid(Hex, spiral({radius: 3}))
+  // const Hex = defineHex({ dimensions: 50, origin: 'topLeft' })
+  // const grid = new Grid(Hex, spiral({radius: 3}))
 
-  const hexagondata: HexagonProps[] = []
+  // const hexagondata: HexagonProps[] = []
 
-  grid.forEach((hex) => {
-    hexagondata.push({coords: hex.toString(), points: hex.corners, piece: "B", isOuter: true})
+  // grid.forEach((hex) => {
+  //   hexagondata.push({coords: hex.toString(), points: hex.corners, center: hex.center, piece: "B", isOuter: true})
+  // })
+
+  const hexdata: HexagonProps[] = hexes.map(hex => {
+    return {
+      coords: JSON.stringify({q: hex.q, r: hex.r}),
+      points: hex.corners,
+      piece: hex.fill,
+      isOuter: true
+    }
   })
 
   return (<svg
   className="grid"
   width="800"
-  height="600"
+  height="800"
   viewBox="-350 -250 800 600"
   version="1.1"
   xmlns="http://www.w3.org/2000/svg"
 >
   <g>
-    {hexagondata.map((h) => <Hexagon data={h} />)}
+    {hexdata.map((h) => <Hexagon data={h} />)}
   </g>
 </svg>)
 }

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -13,7 +13,8 @@ type GridHexData = {
   fill: string;
   q: number;
   r: number;
-  corners: Point[]
+  corners: Point[];
+  center: Point;
 }
 
 export const Board = ( {hexes}: {hexes: GridHexData[]} ) => {
@@ -24,6 +25,7 @@ export const Board = ( {hexes}: {hexes: GridHexData[]} ) => {
       coords: JSON.stringify({q: hex.q, r: hex.r}),
       points: hex.corners,
       piece: hex.fill,
+      center: hex.center,
       isOuter: true
     }} key={JSON.stringify({q: hex.q, r: hex.r})} />
   })
@@ -37,7 +39,6 @@ export const Board = ( {hexes}: {hexes: GridHexData[]} ) => {
   xmlns="http://www.w3.org/2000/svg"
 >
   <g>
-    {/* {hexdata.map((h) => <Hexagon data={h} />)} */}
     {hexagons}
   </g>
 </svg>)

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -9,15 +9,23 @@ export type HexagonProps = {
   center?: Point;
 }
 
-export const Board = ({ hexes } ) => {
+type GridHexData = {
+  fill: string;
+  q: number;
+  r: number;
+  corners: Point[]
+}
 
-  const hexdata: HexagonProps[] = hexes.map(hex => {
-    return {
+export const Board = ( {hexes}: {hexes: GridHexData[]} ) => {
+
+  const hexagons = hexes.map((hex: GridHexData) => {
+    return <Hexagon
+    data={{
       coords: JSON.stringify({q: hex.q, r: hex.r}),
       points: hex.corners,
       piece: hex.fill,
       isOuter: true
-    }
+    }} key={JSON.stringify({q: hex.q, r: hex.r})} />
   })
 
   return (<svg
@@ -29,7 +37,8 @@ export const Board = ({ hexes } ) => {
   xmlns="http://www.w3.org/2000/svg"
 >
   <g>
-    {hexdata.map((h) => <Hexagon data={h} />)}
+    {/* {hexdata.map((h) => <Hexagon data={h} />)} */}
+    {hexagons}
   </g>
 </svg>)
 }

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,18 +1,11 @@
 import { Point } from 'honeycomb-grid'
 import { Hexagon } from "./Hexagon"
+import { GridHexData } from "../../../backend/src/shared/types/gridhexdata"
 
 export type HexagonProps = {
   coords: string;
   points: Point[];
   piece?: string;
-  outer: boolean;
-}
-
-type GridHexData = {
-  fill: string;
-  q: number;
-  r: number;
-  corners: Point[];
   outer: boolean;
 }
 

--- a/frontend/src/components/Hexagon.css
+++ b/frontend/src/components/Hexagon.css
@@ -1,0 +1,11 @@
+.hexagon {
+  fill:aquamarine;
+  stroke: #666;
+  stroke-width: 3px;
+  transition: all 0.3s ease;
+}
+
+.hexagon:hover {
+  fill:rgb(251, 132, 111);
+
+}

--- a/frontend/src/components/Hexagon.css
+++ b/frontend/src/components/Hexagon.css
@@ -1,14 +1,19 @@
 .hexagon polygon {
-  fill:rgb(99, 220, 194);
-  stroke: #666;
+  fill:rgb(113, 242, 214);
+  stroke: #fff;
   stroke-width: 3px;
   transition: all 0.3s ease;
 }
 
-.hexagon:hover polygon {
+.outer polygon {
+  fill: rgb(99, 220, 194);
+}
+
+.outer:hover polygon {
   fill:rgb(251, 111, 158);
 
 }
+
 
 .hexagon .B {
   fill: #222;

--- a/frontend/src/components/Hexagon.css
+++ b/frontend/src/components/Hexagon.css
@@ -1,11 +1,19 @@
-.hexagon {
-  fill:aquamarine;
+.hexagon polygon {
+  fill:rgb(99, 220, 194);
   stroke: #666;
   stroke-width: 3px;
   transition: all 0.3s ease;
 }
 
-.hexagon:hover {
-  fill:rgb(251, 132, 111);
+.hexagon:hover polygon {
+  fill:rgb(251, 111, 158);
 
+}
+
+.hexagon .B {
+  fill: #222;
+}
+
+.hexagon .W {
+  fill: antiquewhite;
 }

--- a/frontend/src/components/Hexagon.tsx
+++ b/frontend/src/components/Hexagon.tsx
@@ -1,8 +1,11 @@
 import { Point } from "honeycomb-grid"
-// import { HexagonProps } from "./Board"
+import { HexagonProps } from "./Board"
 
-export const Hexagon = ({ data }) => {
-  console.log(data)
+type PropsData = {
+  data: HexagonProps;
+}
+
+export const Hexagon = ({ data }: PropsData) => {
 
   const formatPoints = (pointsarray: Point[]): string => {
     return pointsarray.map(coord => `${coord.x},${coord.y}`).join(" ")

--- a/frontend/src/components/Hexagon.tsx
+++ b/frontend/src/components/Hexagon.tsx
@@ -1,0 +1,20 @@
+import { Point } from "honeycomb-grid"
+// import { HexagonProps } from "./Board"
+
+export const Hexagon = ({ data }) => {
+  console.log(data)
+
+  const formatPoints = (pointsarray: Point[]): string => {
+    return pointsarray.map(coord => `${coord.x},${coord.y}`).join(" ")
+  }
+
+  const clickHandle = () => {
+    console.log("click")
+  }
+
+  return (
+    <g className="hexagon" onClick={clickHandle}>
+      <polygon points={formatPoints(data.points)} />
+    </g>
+  )
+}

--- a/frontend/src/components/Hexagon.tsx
+++ b/frontend/src/components/Hexagon.tsx
@@ -15,9 +15,13 @@ export const Hexagon = ({ data }: PropsData) => {
     console.log("click")
   }
 
+  const centerX = data.points.reduce((sum, vertex) => sum + vertex.x, 0) / 6
+  const centerY = data.points.reduce((sum, vertex) => sum + vertex.y, 0) / 6
+
   return (
     <g className="hexagon" onClick={clickHandle}>
       <polygon points={formatPoints(data.points)} />
+      {data.piece && <circle className={data.piece} cx={centerX} cy={centerY} r="25" />}
     </g>
   )
 }

--- a/frontend/src/components/Hexagon.tsx
+++ b/frontend/src/components/Hexagon.tsx
@@ -17,9 +17,10 @@ export const Hexagon = ({ data }: PropsData) => {
 
   const centerX = data.points.reduce((sum, vertex) => sum + vertex.x, 0) / 6
   const centerY = data.points.reduce((sum, vertex) => sum + vertex.y, 0) / 6
+  const classes = `hexagon ${data.outer ? "outer" : ""}`
 
   return (
-    <g className="hexagon" onClick={clickHandle}>
+    <g className={classes} onClick={clickHandle}>
       <polygon points={formatPoints(data.points)} />
       {data.piece && <circle className={data.piece} cx={centerX} cy={centerY} r="25" />}
     </g>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,5 @@
+@import "./components/Hexagon.css";
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
The app now has a Board component that renders an svg grid of Hexagon components. A `serialise()` method has been added to the Board class on the backend, to convert all relevant data into a JSON for sending to the frontend.

- [x] create React component for hexagon
- [x] create React component for board
- [x] display board when player has joined a room
- [x] render received board data from backend
- [x] type safety
- [x] render pieces on board
- [x] differentiate outer tiles

Next steps are to add functionality allowing player to place a piece.