### PR TITLE
Gipf-81/gipf-83 fix backend response

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -54,13 +54,13 @@ const server = Bun.serve<{ name: string; }>({
         let room = lobby.rooms[message.data.room];
         if (room) {
           // place piece at coord
-          const rows = room.game.placePiece(JSON.parse(message.data.coord))
-          // return legal rows to push to
+          const tiles = room.game.getPushableTiles(JSON.parse(message.data.coord))
+          // return legal tiles to push to
           let response = {
             type: "moveValidityResponse",
             data: {
-              valid: rows.length > 0,
-              rows: rows
+              valid: tiles.length > 0,
+              tiles: tiles
           }}
           ws.send(JSON.stringify(response))
           // no need to update board until the move is confirmed

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -63,6 +63,7 @@ const server = Bun.serve<{ name: string; }>({
               rows: rows
           }}
           ws.send(JSON.stringify(response))
+          // no need to update board until the move is confirmed
       }}
 
       // player makes a move

--- a/backend/src/logic/Game.ts
+++ b/backend/src/logic/Game.ts
@@ -27,7 +27,7 @@ export class Game {
   }
 
   // board is not updated; we only update the board after a move.
-  placePiece(coord: HexCoordinates) {
+  getPushableTiles(coord: HexCoordinates) {
     // const player = this.currentPlayerBlack ? "black" : "white";
     const legalTiles = this.board
       .getInnerNeighbours(coord)

--- a/backend/src/logic/Game.ts
+++ b/backend/src/logic/Game.ts
@@ -26,21 +26,25 @@ export class Game {
     }
   }
 
+  // board is not updated; we only update the board after a move.
   placePiece(coord: HexCoordinates) {
-    const player = this.currentPlayerBlack ? "black" : "white";
+    // const player = this.currentPlayerBlack ? "black" : "white";
     const legalTiles = this.board
       .getInnerNeighbours(coord)
       .filter((tile) => this.board.isPushable(this.board.getRow(coord, tile)))
       .toArray();
-    if (legalTiles.length > 0) {
-      this.board.fillTile(coord, player);
-      this.score[player] -= 1;
-    }
+    // if (legalTiles.length > 0) {
+    //   this.board.fillTile(coord, player);
+    //   this.score[player] -= 1;
+    // }
     return legalTiles;
-    // return this.board.printBoard()
   }
 
   makeMove(coordOuter: HexCoordinates, coordInner: HexCoordinates) {
+    const player = this.currentPlayerBlack ? "black" : "white";
+    this.board.fillTile(coordOuter, player);
+    this.score[player] -= 1;
+
     this.board.pushPiece(coordOuter, coordInner);
     const matches = this.board.checkAllRows();
     if (matches.length > 1) {

--- a/backend/src/tests/integration/game.int.test.ts
+++ b/backend/src/tests/integration/game.int.test.ts
@@ -23,7 +23,7 @@ test("I can create a game and see that it has a board and the players have start
 // ---
 test("I can place a piece and my piece count will decrease", () => {
   expect(game.score.black).toBe(15);
-  const response = game.placePiece([4, -1]);
+  const response = game.getPushableTiles([4, -1]);
   game.makeMove([4, -1], [response[0].q, response[0].r]);
   expect(game.score.black).toBe(14);
   expect(response[0].fill).toBe("B");
@@ -34,14 +34,14 @@ test("I can place a piece and my piece count will decrease", () => {
 // 2. when I place the fourth tile I receive back all four tiles (check number)
 // 3. those tiles are no longer on the board
 test("I can place 4 tiles in a row and my piece count will be updated", () => {
-  game.placePiece([4, -1]);
+  game.getPushableTiles([4, -1]);
   game.makeMove([4, -1], [3, -1]);
-  game.placePiece([4, -1]);
+  game.getPushableTiles([4, -1]);
   game.makeMove([4, -1], [3, -1]);
-  game.placePiece([4, -1]);
+  game.getPushableTiles([4, -1]);
   game.makeMove([4, -1], [3, -1]);
   expect(game.score.black).toBe(12);
-  game.placePiece([4, -1]);
+  game.getPushableTiles([4, -1]);
   game.makeMove([4, -1], [3, -1]);
   expect(game.score.black).toBe(15);
 });
@@ -50,20 +50,20 @@ test("I can place 4 tiles in a row and my piece count will be updated", () => {
 // see notes of situations where one player will lose tiles
 // I see that I have lost tiles that are no longer in play ...
 test("captured pieces in the row are removed from play and not returned", () => {
-  game.placePiece([4, -1]);
+  game.getPushableTiles([4, -1]);
   game.makeMove([4, -1], [3, -1]);
   game.endTurn();
   for (let i = 0; i < 3; i++) {
-    game.placePiece([4, -1]);
+    game.getPushableTiles([4, -1]);
     game.makeMove([4, -1], [3, -1]);
     game.endTurn();
-    game.placePiece([1, -4]);
+    game.getPushableTiles([1, -4]);
     game.makeMove([1, -4], [0, -3]);
     game.endTurn();
   }
   expect(game.score).toEqual({ black: 11, white: 12 });
   expect(game.board.grid.getHex([-2, -1])?.fill).toBe("B");
-  game.placePiece([4, -1]); //white move
+  game.getPushableTiles([4, -1]); //white move
   game.makeMove([4, -1], [3, -1]);
   expect(game.board.grid.getHex([-2, -1])?.fill).toBe("");
   expect(game.board.grid.getHex([-1, -2])?.fill).toBe("B"); //tile outside row should be unaffected

--- a/backend/src/websocket/Room.ts
+++ b/backend/src/websocket/Room.ts
@@ -28,14 +28,14 @@ export class Room {
 
   broadcast(message: any) {
     this.sockets.forEach((socket) => {
-      socket.send(JSON.stringify(message))
-    })
+      socket.send(JSON.stringify(message));
+    });
   }
 
   sendBoardUpdate() {
     this.broadcast({
       type: "boardUpdate",
-      data: {grid: this.game.board.serialise()}
-    })
+      data: { grid: this.game.board.serialise() },
+    });
   }
 }

--- a/backend/src/websocket/Room.ts
+++ b/backend/src/websocket/Room.ts
@@ -26,7 +26,7 @@ export class Room {
     }
   }
 
-  broadcast(message: any) {
+  broadcast(message: unknown) {
     this.sockets.forEach((socket) => {
       socket.send(JSON.stringify(message));
     });


### PR DESCRIPTION
Redefines and renames the `placePiece` function to only return legal tiles without changing board state. This is to reduce board update messages if the player selects and deselects tiles a lot.

Board state changes have been moved to the `makeMove` function.